### PR TITLE
Replace support-v4 with support-annotations

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0-beta5'
+        classpath 'com.android.tools.build:gradle:2.1.0'
     }
 }
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply from: '../build-config/gradle-quality.gradle'
 
 dependencies {
-    compile 'com.android.support:support-v4:23.1.1'
+    compile 'com.android.support:support-annotations:23.3.0'
 }
 
 android {

--- a/library/src/main/java/net/vrallev/android/cat/CatUtil.java
+++ b/library/src/main/java/net/vrallev/android/cat/CatUtil.java
@@ -1,6 +1,6 @@
 package net.vrallev.android.cat;
 
-import android.support.v4.util.LruCache;
+import android.util.LruCache;
 
 /**
  * @author rwondratschek


### PR DESCRIPTION
Hi, I notice `support-v4` dependency is mostly required for annotations. Replacing it with `support-annotations` would drop ~9k methods from the library.

`android.support.v4.util.LruCache` can be replaced with `android.util.LruCache`. This should be safe as it requires API 12, while project's `minSdkVersion` is 14.
